### PR TITLE
Publish Initial Zone Status

### DIFF
--- a/components/dsc_alarm_panel/dscAlarm.h
+++ b/components/dsc_alarm_panel/dscAlarm.h
@@ -346,6 +346,9 @@ class DSCkeybushome : public api::CustomAPIDevice, public PollingComponent
       void set_trouble_fetch_cmd(const char *cmd);
       void createZone(uint16_t z,uint8_t p=0);
       void createZoneFromId(const char * zid,uint8_t p=0);
+
+      void publishAllZoneStatuses();
+
       void stop();
 
     private:


### PR DESCRIPTION
### Explanation of Changes

-   By calling `publishAllZoneStatuses()` at the end of `setup()/begin()`, all zone statuses are published as soon as the system boots, rather than waiting for a change event.
-   This should handle both MQTT and non-MQTT setups by leveraging existing publishing mechanisms (`publishBinaryState` for ESPHome and callbacks for MQTT).
-   Keybus connection check ensures statuses are only published when the system is ready, avoiding invalid data.

### Notes

-   **Zone Initialization**: Ensure `zoneStatus` is populated with valid data (e.g., open states) before calling `publishAllZoneStatuses()`. If the DSC panel hasn’t yet provided this data during boot, the initial states might be false (closed) until the first update from the Keybus.