### PR TITLE
- fix missing DISABLE_EXPANDER gate

### DIFF
--- a/components/dsc_alarm_panel/dscAlarm.cpp
+++ b/components/dsc_alarm_panel/dscAlarm.cpp
@@ -137,7 +137,9 @@ void DSCkeybushome::publishTextState(const std::string &idstr, uint8_t num, std:
     void DSCkeybushome::set_trouble_fetch_cmd(const char *cmd) { fetchCmd = cmd; }
     void DSCkeybushome::set_expanderAddr(uint8_t addr)
     {
+#if not defined(DISABLE_EXPANDER)
       dsc.addModule(addr);
+#endif
     }
     void DSCkeybushome::set_refresh_time(uint8_t rt)
     {


### PR DESCRIPTION
@Dilbert66 Fixes a missing `#if not defined(DISABLE_EXPANDER)` gate, avoiding the below error during linking phase.

```
Linking .pioenvs/dscalarm/firmware.elf
/config/.esphome/platformio/packages/toolchain-xtensa-esp32@8.4.0+2021r2-patch5/bin/../lib/gcc/xtensa-esp32-elf/8.4.0/../../../../xtensa-esp32-elf/bin/ld: .pioenvs/dscalarm/src/esphome/components/dsc_alarm_panel/dscAlarm.cpp.o:(.literal._ZN7esphome11alarm_panel13DSCkeybushome16set_expanderAddrEh+0x0): undefined reference to `dscKeybusInterface::addModule(unsigned char)'
/config/.esphome/platformio/packages/toolchain-xtensa-esp32@8.4.0+2021r2-patch5/bin/../lib/gcc/xtensa-esp32-elf/8.4.0/../../../../xtensa-esp32-elf/bin/ld: .pioenvs/dscalarm/src/esphome/components/dsc_alarm_panel/dscAlarm.cpp.o: in function `esphome::alarm_panel::DSCkeybushome::set_expanderAddr(unsigned char)':
/config/.esphome/build/dscalarm/src/esphome/components/dsc_alarm_panel/dscAlarm.cpp:140: undefined reference to `dscKeybusInterface::addModule(unsigned char)'
collect2: error: ld returned 1 exit status
```