### PR TITLE
Added sensor type id validation

### DIFF
--- a/components/dsc_alarm_panel/__init__.py
+++ b/components/dsc_alarm_panel/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 from esphome.core import CORE
+import re
 import os
 import logging
     
@@ -28,7 +29,18 @@ CONF_REFRESHTIME="trouble_fetch_update_time"
 CONF_TROUBLEFETCH="trouble_fetch"
 CONF_TROUBLEFETCHCMD="trouble_fetch_cmd"
 CONF_EVENTFORMAT="event_format"
-CONF_TYPE_ID="code"
+CONF_TYPE_ID = "id_code"
+CONF_PARTITION="partition"
+CONF_ALARM_ID = "alarm_id"
+CONF_SORTING_GROUP_ID = "sorting_group_id"
+CONF_SORTING_WEIGHT = "sorting_weight"
+CONF_WEB_KEYPAD_ID="web_keypad_id"
+CONF_WEB_KEYPAD="web_keypad"
+
+BINARY_SENSOR_TYPE_ID_REGEX = "^(tr|bat|ac|rdy_\d+|arm_\d+|al_\d+|fa_\d+|chm_\d+|r\d+|z\d+)$"
+BINARY_SENSOR_TYPE_ID_DESCRIPTION = "tr, bat, ac, rdy_<digits>, arm_<digits>, al_<digits>, fa_<digits>, chm_<digits>, r<digits>, z<digits>"
+TEXT_SENSOR_TYPE_ID_REGEX = "^(ss|zs|tr_msg|evt|ps_\d+|msg_\d+|ln1_\d+|ln2_\d+|bp_\d+|za_\d+|user_\d+)$"
+TEXT_SENSOR_TYPE_ID_DESCRIPTION = "ss, zs, tr_msg, evt, ps_<digits>, msg_<digits>, ln1_<digits>, ln2_<digits>, bp_<digits>, za_<digits>, user_<digits>"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -52,6 +64,27 @@ CONFIG_SCHEMA = cv.Schema(
     cv.Optional(CONF_AUTOPOPULATE,default='false'): cv.boolean,
     cv.Optional(CONF_DETAILEDPARTITIONSTATE,default='false'):cv.boolean,
     cv.Optional(CONF_EVENTFORMAT,default='plain'): cv.one_of('json','plain',lower=True),    
+    }
+)
+
+web_keypad_ns = cg.esphome_ns.namespace("web_keypad")
+WebKeypad = web_keypad_ns.class_("WebServer", cg.Component, cg.Controller)
+
+WEBKEYPAD_SORTING_SCHEMA = cv.Schema(
+    {
+         cv.Optional(CONF_WEB_KEYPAD): cv.Schema(
+             {
+                cv.OnlyWith(CONF_WEB_KEYPAD_ID, "web_keypad"): cv.use_id(WebKeypad),
+                cv.Optional(CONF_SORTING_WEIGHT): cv.All(
+                    cv.requires_component("web_keypad"),
+                    cv.float_,
+                ),
+                cv.Optional(CONF_SORTING_GROUP_ID): cv.All(
+                    cv.requires_component("web_keypad"),
+                    cv.use_id(cg.int_),
+                ),
+             }
+         )
     }
 )
 
@@ -96,12 +129,32 @@ async def to_code(config):
   
     await cg.register_component(var, config)
    
-
-    
 def real_clean_build():
     import shutil
     build_dir = CORE.relative_build_path("")
     if os.path.isdir(build_dir):
         _LOGGER.info("Deleting %s", build_dir)
         shutil.rmtree(build_dir)
-    
+
+def validate_id_code(value, is_binary_sensor=True):
+    """Validate the type_id for binary or text sensors."""
+    if is_binary_sensor:
+        regex = BINARY_SENSOR_TYPE_ID_REGEX
+        description = BINARY_SENSOR_TYPE_ID_DESCRIPTION
+    else:
+        regex = TEXT_SENSOR_TYPE_ID_REGEX
+        description = TEXT_SENSOR_TYPE_ID_DESCRIPTION
+
+    if not value or not re.fullmatch(regex, value):
+        raise cv.Invalid(f"Invalid type_id '{value}'. Allowed formats: {description}")
+        
+    return value
+
+def generate_validate_sensor_config(is_binary_sensor=True):
+    """Generate a validation function for sensor configuration."""
+    def validate_sensor_config(config):
+        id_val = config.get(CONF_TYPE_ID) or config[CONF_ID].id
+        validate_id_code(id_val, is_binary_sensor)
+        return config
+
+    return validate_sensor_config

--- a/components/dsc_alarm_panel/binary_sensor/__init__.py
+++ b/components/dsc_alarm_panel/binary_sensor/__init__.py
@@ -3,55 +3,25 @@ import esphome.config_validation as cv
 from esphome.const import CONF_ID
 from esphome.helpers import sanitize, snake_case
 from esphome.components import binary_sensor
-
-from .. import component_ns,AlarmComponent
-
-CONF_TYPE_ID = "id_code"
-CONF_PARTITION="partition"
-CONF_ALARM_ID = "alarm_id"
-CONF_SORTING_GROUP_ID = "sorting_group_id"
-CONF_SORTING_WEIGHT = "sorting_weight"
-CONF_WEB_KEYPAD_ID="web_keypad_id"
-CONF_WEB_KEYPAD="web_keypad"
+from .. import component_ns, AlarmComponent, validate_id_code, generate_validate_sensor_config
+from .. import CONF_TYPE_ID, CONF_ALARM_ID, CONF_WEB_KEYPAD, CONF_PARTITION, WEBKEYPAD_SORTING_SCHEMA
 
 AlarmBinarySensor = component_ns.class_(
     "AlarmBinarySensor", binary_sensor.BinarySensor, cg.Component
 )
 
-web_keypad_ns = cg.esphome_ns.namespace("web_keypad")
-WebKeypad = web_keypad_ns.class_("WebServer", cg.Component, cg.Controller)
-
-WEBKEYPAD_SORTING_SCHEMA = cv.Schema(
-    {
-         cv.Optional(CONF_WEB_KEYPAD): cv.Schema(
-             {
-                cv.OnlyWith(CONF_WEB_KEYPAD_ID, "web_keypad"): cv.use_id(WebKeypad),
-                cv.Optional(CONF_SORTING_WEIGHT): cv.All(
-                    cv.requires_component("web_keypad"),
-                    cv.float_,
-                ),
-                cv.Optional(CONF_SORTING_GROUP_ID): cv.All(
-                    cv.requires_component("web_keypad"),
-                    cv.use_id(cg.int_),
-                ),
-             }
-         )
-    }
-)
-
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     binary_sensor.binary_sensor_schema(AlarmBinarySensor)
     .extend(
         {
-            cv.Optional(CONF_TYPE_ID, default=""): cv.string_strict,  
+            cv.Optional(CONF_TYPE_ID, default=""): cv.Any(cv.string_strict, validate_id_code),
             cv.Optional(CONF_PARTITION,default=0): cv.int_,
             cv.GenerateID(CONF_ALARM_ID): cv.use_id(AlarmComponent),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(WEBKEYPAD_SORTING_SCHEMA)
-
-
+    .extend(WEBKEYPAD_SORTING_SCHEMA),
+    generate_validate_sensor_config(True) # True indicates this is a binary sensor
 )
 
 async def setup_entity_alarm(var, config):

--- a/components/dsc_alarm_panel/dscAlarm.h
+++ b/components/dsc_alarm_panel/dscAlarm.h
@@ -203,27 +203,38 @@ namespace esphome
 
 #define mlsize 2
 
+// binary, no zone
 #define TRSTATUS "tr"
 #define BATSTATUS "bat"
 #define ACSTATUS "ac"
+
+// binary, has numeric suffix with "_" prefix
 #define RDYSTATUS "rdy"
 #define ARMSTATUS "arm"
-#define SYSTEMSTATUS "ss"
-#define PARTITIONSTATUS "ps"
 #define ALARMSTATUS "al"
+#define FIRE "fa"
+#define CHIMESTATUS "chm"
+
+// text, no zone
+#define SYSTEMSTATUS "ss"
+#define ZONESTATUS "zs"
+#define TROUBLE "tr_msg"
+#define EVENT "evt"
+
+// text, has numeric suffix with "_" prefix
+#define PARTITIONSTATUS "ps"
 #define PARTITIONMSG "msg"
 #define LINE1 "ln1"
 #define LINE2 "ln2"
 #define BEEP "bp"
 #define ZONEALARM "za"
 #define USER "user"
-#define ZONESTATUS "zs"
-#define TROUBLE "tr_msg"
-#define EVENT "evt"
-#define FIRE "fa"
+
+// binary, has numeric suffix without "_"
 #define RELAY "r"
 #define ZONE "z"
-#define CHIMESTATUS "chm"
+
+// misc
 #define TRIGGERED "triggered"
 
 #if !defined(USE_API)
@@ -291,7 +302,7 @@ class DSCkeybushome : public api::CustomAPIDevice, public PollingComponent
 #else
     if (zt->binary_sensor != NULL)
       zt->binary_sensor->publish_state(zt->open);
-   
+
 #endif
       }
 

--- a/components/dsc_alarm_panel/text_sensor/__init__.py
+++ b/components/dsc_alarm_panel/text_sensor/__init__.py
@@ -2,55 +2,26 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import text_sensor
 from esphome.helpers import sanitize, snake_case
-from esphome.const import (
-    CONF_ID,
-
-)
-from .. import component_ns,AlarmComponent
-
-CONF_TYPE_ID = "id_code"
-CONF_PARTITION="partition"
-CONF_ALARM_ID = "alarm_id"
-CONF_SORTING_GROUP_ID = "sorting_group_id"
-CONF_SORTING_WEIGHT = "sorting_weight"
-CONF_WEB_KEYPAD_ID="web_keypad_id"
-CONF_WEB_KEYPAD="web_keypad"
+from esphome.const import CONF_ID
+from .. import component_ns, AlarmComponent, validate_id_code, generate_validate_sensor_config, CONF_TYPE_ID
+from .. import CONF_TYPE_ID, CONF_ALARM_ID, CONF_WEB_KEYPAD, CONF_PARTITION, WEBKEYPAD_SORTING_SCHEMA
 
 AlarmTextSensor = component_ns.class_(
     "AlarmTextSensor", text_sensor.TextSensor, cg.PollingComponent
 )
 
-web_keypad_ns = cg.esphome_ns.namespace("web_keypad")
-WebKeypad = web_keypad_ns.class_("WebServer", cg.Component, cg.Controller)
-
-WEBKEYPAD_SORTING_SCHEMA = cv.Schema(
-    {
-         cv.Optional(CONF_WEB_KEYPAD): cv.Schema(
-             {
-                cv.OnlyWith(CONF_WEB_KEYPAD_ID, "web_keypad"): cv.use_id(WebKeypad),
-                cv.Optional(CONF_SORTING_WEIGHT): cv.All(
-                    cv.requires_component("web_keypad"),
-                    cv.float_,
-                ),
-                cv.Optional(CONF_SORTING_GROUP_ID): cv.All(
-                    cv.requires_component("web_keypad"),
-                    cv.use_id(cg.int_),
-                ),
-             }
-         )
-    }
-)
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     text_sensor.text_sensor_schema()
     .extend(
         {
-            cv.Optional(CONF_TYPE_ID, default=""): cv.string_strict,  
+            cv.Optional(CONF_TYPE_ID, default=""): cv.Any(cv.string_strict, validate_id_code),
             cv.Optional(CONF_PARTITION,default=0): cv.int_,
             cv.GenerateID(CONF_ALARM_ID): cv.use_id(AlarmComponent),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(WEBKEYPAD_SORTING_SCHEMA)
+    .extend(WEBKEYPAD_SORTING_SCHEMA),
+    generate_validate_sensor_config(False)  # False indicates this is not a binary sensor, but a text sensor
 )
 
 async def setup_entity_alarm(var, config):


### PR DESCRIPTION
My suggestion for adding a sensor type id validation.
This takes into account that either `id` or `id_code` is used to identify dsc alarm function code.