### PR TITLE
Fix DSCAlarm for ESPHome 2025.8.0 (StaticVector change)

### DIFF
--- a/components/dsc_alarm_panel/dscAlarm.h
+++ b/components/dsc_alarm_panel/dscAlarm.h
@@ -383,8 +383,8 @@ class DSCkeybushome : public api::CustomAPIDevice, public PollingComponent
       void stop();
 
     private:
-      std::vector<binary_sensor::BinarySensor *> bMap;
-      std::vector<text_sensor::TextSensor *> tMap;
+      esphome::StaticVector<esphome::binary_sensor::BinarySensor*, 45> bMap;
+      esphome::StaticVector<esphome::text_sensor::TextSensor*, 23> tMap;
 
       int activePartition = 1;
       unsigned long cmdWaitTime;


### PR DESCRIPTION
Full disclosure - this fix was primarily generated using ChatGPT.

ESPHome 2025.8.0, released 20 August 2025, seems to break the compilation due to a change around std::vector.

It seems this release changed App.get_binary_sensors() and App.get_text_sensors() to return StaticVector instead of std::vector, so this PR updates dscAlarm.h to match.