### PR TITLE
updates for RP2040

### DIFF
--- a/components/vista_alarm_panel/ECPSoftwareSerial.cpp
+++ b/components/vista_alarm_panel/ECPSoftwareSerial.cpp
@@ -94,19 +94,27 @@ portMUX_TYPE SoftwareSerial::m_interruptsMux = portMUX_INITIALIZER_UNLOCKED;
 
 ALWAYS_INLINE_ATTR inline void IRAM_ATTR SoftwareSerial::disableInterrupts()
 {
-#ifndef ESP32
+#ifdef ESP8266
     m_savedPS = xt_rsil(15);
-#else
+#endif
+#ifdef ESP32
     taskENTER_CRITICAL(&m_interruptsMux);
+#endif
+#ifdef USE_RP2040
+    m_savedPS = save_and_disable_interrupts();
 #endif
 }
 
 ALWAYS_INLINE_ATTR inline void IRAM_ATTR SoftwareSerial::restoreInterrupts()
 {
-#ifndef ESP32
+#ifdef ESP8266
     xt_wsr_ps(m_savedPS);
-#else
+#endif
+#ifdef ESP32
     taskEXIT_CRITICAL(&m_interruptsMux);
+#endif
+#ifdef USE_RP2040
+    restore_interrupts(m_savedPS);
 #endif
 }
 

--- a/components/vista_alarm_panel/ECPSoftwareSerial.h
+++ b/components/vista_alarm_panel/ECPSoftwareSerial.h
@@ -63,10 +63,6 @@ typedef char byte;
 #define IRAM_ATTR
 #endif
 
-#if defined(USE_RP2040) && not defined(ESP)
-#define ESP rp2040
-#endif
-
 // If only one tx or rx wanted then use this as parameter for the unused pin
 constexpr int SW_SERIAL_UNUSED_PIN = -1;
 
@@ -181,7 +177,7 @@ private:
     {
         // return (ESP.getCpuFreqMHz() * micros) << 1;
        // return ((esp_clk_cpu_freq()/1000000) * micros) << 1;
-       #ifdef USE_ARDUINO
+       #if defined(USE_ARDUINO) && not defined(USE_RP2040)
        return (ESP.getCpuFreqMHz() * micros) ;
        #else
        return micros << 1;
@@ -194,7 +190,7 @@ private:
 
     static inline unsigned long IRAM_ATTR ticks()  ALWAYS_INLINE_ATTR
     {
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) && not defined(USE_RP2040)
 return ESP.getCycleCount() ;
 #else
 

--- a/components/vista_alarm_panel/vista.cpp
+++ b/components/vista_alarm_panel/vista.cpp
@@ -99,19 +99,27 @@ portMUX_TYPE Vista::m_interruptsMux = portMUX_INITIALIZER_UNLOCKED;
 
 ALWAYS_INLINE_ATTR inline void IRAM_ATTR Vista::disableInterrupts()
 {
-#ifndef ESP32
+#ifdef ESP8266
    m_savedPS = xt_rsil(15);
-#else
+#endif
+#ifdef ESP32
     taskENTER_CRITICAL(&m_interruptsMux);
+#endif
+#ifdef USE_RP2040
+    m_savedPS = save_and_disable_interrupts();
 #endif
 }
 
 ALWAYS_INLINE_ATTR inline void IRAM_ATTR Vista::restoreInterrupts()
 {
-#ifndef ESP32
+#ifdef ESP8266
     xt_wsr_ps(m_savedPS);
-#else
+#endif
+#ifdef ESP32
     taskEXIT_CRITICAL(&m_interruptsMux);
+#endif
+#ifdef USE_RP2040
+    restore_interrupts(m_savedPS);
 #endif
 }
 

--- a/components/vista_alarm_panel/vistaalarm.h
+++ b/components/vista_alarm_panel/vistaalarm.h
@@ -44,10 +44,6 @@ typedef char __FlashStringHelper;
 #include "paneltext.h"
 #include "Regexp.h"
 
-#if defined(USE_RP2040) && not defined(ESP)
-#define ESP rp2040
-#endif
-
 // for documentation see project at https://github.com/Dilbert66/esphome-vistaecp
 
 #define KP_ADDR 17 // only used as a default if not set in the yaml


### PR DESCRIPTION
- added RP2040 code for disabling and restoring interrupts
- revert ESP.getCpuFreqMHz() changes for Arduino to exclude RP2040
- clean-up no longer needed `#define ESP rp2040`