### PR TITLE
dsc_alarm_panel: expose update_interval with sane default (fix ESPHome 2026.4.0 crash loop)

### DIFF
--- a/components/dsc_alarm_panel/__init__.py
+++ b/components/dsc_alarm_panel/__init__.py
@@ -72,7 +72,7 @@ CONFIG_SCHEMA = cv.Schema(
     cv.Optional(CONF_STACK_SIZE):cv.int_, 
     cv.Optional(CONF_USE_ESP_IDF_TIMER,default='true'):cv.boolean, 
     }
-)
+).extend(cv.polling_component_schema("8ms"))
 
 web_keypad_ns = cg.esphome_ns.namespace("web_keypad")
 WebKeypad = web_keypad_ns.class_("WebServer", cg.Component, cg.Controller)


### PR DESCRIPTION
## Summary

`DSCkeybushome` inherits from `PollingComponent`, but the component never sets an `update_interval` — not via the base-class constructor, not via config schema. So `update_interval_` defaults to `0`.

Before ESPHome 2026.4.0, `Scheduler::call` routed re-armed interval items through `to_add_`, which was only merged back into the heap at the next `call()`. An interval with delay=0 effectively ran once per main-loop iteration and things worked.

In 2026.4.0 the scheduler was optimized to push re-armed intervals directly back into `items_` while holding the `now_64` value captured at the top of `call()` (see the comment in `scheduler.cpp`: *"This avoids the to_add_ detour"*). With `interval=0`, the re-inserted item has `next_execution == now_64`, the `while` loop never breaks, and the task watchdog on `loopTask` fires after ~5s — **infinite crash loop on boot** for any device using `dsc_alarm_panel` on ESPHome 2026.4.0+.

## Fix

One-line change: extend `CONFIG_SCHEMA` with `cv.polling_component_schema("8ms")`.

ESPHome's `register_component(var, config)` then emits `DSCAlarm->set_update_interval(8);` in the generated `main.cpp` **before** `call_setup()` runs, so `start_poller()` registers a real 8ms interval instead of 0.

The 8ms default matches what `vista_alarm_panel` already sets in its `setup()` (to *"not miss a response window on commands"*). Users can now also override it from YAML, e.g. `update_interval: 100ms`.

## Verification

Tested against an affected device (ESP32 + ESPHome 2026.4.0 + this component on `main`):

- **Before patch:** `ELF SHA256 cd8ac840e` → `E (15195) task_wdt: - loopTask (CPU 1)`, backtrace into `esphome::Scheduler::call` at `scheduler.cpp:665` (the `items_.push_back(executed_item)` re-arm line) → reboot → repeat forever.
- **After patch:** generated `main.cpp` contains `DSCAlarm->set_update_interval(8);` at line 459; **device boots cleanly and is stable in production.**

Schema-level check: default is `8ms`, YAML override accepted (e.g. `update_interval: 500ms` → `500ms`).

## Note on vista_alarm_panel / vista20se

The Vista variants have the same latent bug — they also construct with `update_interval_=0` and only call `set_update_interval(8)` later inside their own `setup()`, which runs **after** `PollingComponent::call_setup()` → `start_poller()` has already registered the interval with 0. They'll likely crash the same way on 2026.4.0+. The same one-line schema extension would fix them. Kept out of this PR to stay minimal — happy to include them in a follow-up if you'd prefer, or in this PR if you'd rather.

## Test plan

- [x] Python schema validation: default resolves to `8ms`, override accepted
- [x] Full build against real YAML + ESPHome 2026.4.0: generated `main.cpp` contains `set_update_interval(8)` at the expected position
- [x] Live device boot verification: device boots stably after applying the patch