### PR TITLE
Fix null-pointer (LoadProhibited) crash in vista_alarm_panel set_panel_time() when called from on_boot

### DIFF
--- a/components/vista_alarm_panel/vistaalarm.cpp
+++ b/components/vista_alarm_panel/vistaalarm.cpp
@@ -564,7 +564,7 @@ void vistaECPHome::publishTextState(const std::string &idstr, uint8_t num, std::
         else
           sendAuiTime();
       }
-      if (vistaCmd->statusFlags.programMode || _auiAddr)
+      if (vistaCmd == nullptr || vistaCmd->statusFlags.programMode || _auiAddr)
         return;
       ESPTime rtc = now();
       if (!rtc.is_valid())


### PR DESCRIPTION
## Summary
`set_panel_time()` dereferences `vistaCmd` (`vistaCmd->statusFlags.programMode`), but `vistaCmd` is only assigned inside `loop()` via `vista.getNextCmd()`. A config that calls `set_panel_time()` from an `on_boot` automation runs during the **setup** phase — before `loop()` has ever executed — so `vistaCmd` is still null, causing a `LoadProhibited` crash and a boot loop on ESP32.

## Root cause / evidence
- ESP32, ESPHome 2026.5.1, ESP-IDF 5.5.4.
- Deterministic crash: `PC 0x400e0381`, `EXCCAUSE 0x1c` (LoadProhibited), `EXCVADDR 0x00000070`.
- `addr2line` resolves the PC to `vistaECPHome::set_panel_time()` at `vistaalarm.cpp:567`, invoked from an `on_boot` lambda (`priority: 7200`).
- `0x70` is the offset of `statusFlags.programMode` within the object, confirming `vistaCmd == nullptr` at the deref.

## Fix
Short-circuit the null pointer before dereferencing:
```cpp
if (vistaCmd == nullptr || vistaCmd->statusFlags.programMode || _auiAddr)
  return;
```
When the panel link isn't initialized yet, `set_panel_time()` simply returns early.

## Test plan
- [x] Compiles on ESPHome 2026.5.1 (ESP32 / ESP-IDF 5.5.4).
- [x] Device boots cleanly (no Guru Meditation, no boot loop) and reports correctly in Home Assistant.