### PR TITLE
Fix stale bypass state after cancelled exit delay

### DIFF
--- a/components/dsc_alarm_panel/dscAlarm.cpp
+++ b/components/dsc_alarm_panel/dscAlarm.cpp
@@ -1808,6 +1808,11 @@ void DSCkeybushome::update()
           if (dsc.exitDelayChanged[partition] || forceRefresh)
           {
             clearZoneAlarms(partition + 1);
+            // A cancelled exit delay never sets armedChanged, but the panel
+            // clears its bypasses when it returns to the disarmed state.
+            if (dsc.exitDelayChanged[partition] && !dsc.exitDelay[partition] &&
+                !dsc.armed[partition] && !dsc.alarm[partition])
+              clearZoneBypass(partition + 1);
             dsc.exitDelayChanged[partition] = false; // Resets the exit delay status flag
           }
 


### PR DESCRIPTION
## Summary

- Clear cached zone-bypass state when exit delay ends with the partition still disarmed.
- Keep the existing armed and alarm paths unchanged.
- Scope the reset to the affected partition.

## Why

Cancelling DSC exit delay returns the partition to disarmed and clears panel bypasses, but that path updates `exitDelayChanged` without necessarily raising `armedChanged`. The component therefore retained stale local `BY:n` flags after the physical panel had cleared them.

## Testing

- Built the combined test revision with ESPHome Device Builder 2026.8.1.
- Deployed it to the physical DSC installation.
- Started arming with Zone 7 bypassed and cancelled during exit delay.
- Confirmed the panel cleared its bypasses and ESPHome dropped the stale `BY:7` state.
- Confirmed the Home Assistant policy then restored only Zone 7.
- Completed a full arm and disarm cycle successfully.
