### PR TITLE
Publish DSC system online state after keybus reconnect

### DIFF
--- a/components/dsc_alarm_panel/dscAlarm.cpp
+++ b/components/dsc_alarm_panel/dscAlarm.cpp
@@ -1607,7 +1607,7 @@ void DSCkeybushome::update()
         if ((dsc.keybusChanged) || forceRefresh)
         {
           dsc.keybusChanged = false; // Resets the Keybus data status flag
-          if (dsc.keybusConnected && millis() - errorTime > 15000)
+          if (dsc.keybusConnected)
           {
             ESP_LOGD(TAG, "Panel keybus connected...");
             publishSystemStatus(FC(STATUS_ONLINE));


### PR DESCRIPTION
## Summary

- Publish DSC System Status as `online` whenever the keybus reports connected.
- Preserve the existing 15-second debounce before publishing `offline`.

## Why

The component could publish `offline` during setup, then consume the connected change before the 15-second gate allowed `online`. A normal startup or reconnect could therefore remain offline until the ten-minute forced refresh even though partition and zone updates were live.

## Testing

- Built the combined test revision with ESPHome Device Builder 2026.8.1.
- Deployed it to the physical DSC installation.
- Confirmed System Status reported `online` promptly after startup.
- Confirmed all ten Home Assistant bypass controls became available.
- Confirmed partition and zone updates remained live.
- Completed a full arm and disarm cycle successfully.
